### PR TITLE
Fix daily scan persistence and add CI test workflow

### DIFF
--- a/.github/workflows/daily_screening_git_storage.yml
+++ b/.github/workflows/daily_screening_git_storage.yml
@@ -120,23 +120,24 @@ jobs:
             echo "No metadata file found"
           fi
 
-      - name: Commit updated fundamental cache
+      - name: Commit updated fundamental cache and scan results
         id: commit
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Add fundamental cache directory
+          # Add fundamental cache directory and daily scan reports
           git add data/fundamentals_cache/
+          git add data/daily_scans/
 
           # Check if there are changes
           if git diff --staged --quiet; then
-            echo "No fundamental cache changes to commit"
+            echo "No fundamental cache or scan changes to commit"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           else
             CHANGED_FILES=$(git diff --staged --name-only | wc -l)
-            echo "Committing $CHANGED_FILES updated fundamental files"
-            git commit -m "chore: update fundamental cache ($CHANGED_FILES stocks) - ${{ steps.date.outputs.date }}"
+            echo "Committing $CHANGED_FILES updated files"
+            git commit -m "chore: update fundamental cache and daily scan - ${{ steps.date.outputs.date }}"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,32 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: |
+          # test_email_full.py is a manual smoke-test script (hits live network/DB/email),
+          # not an automated unit test, so it's excluded from CI.
+          pytest tests/ --ignore=tests/test_email_full.py -v

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -262,7 +262,7 @@ class TestFetchPriceHistory:
 
             assert not result.empty
             assert len(result) == len(mock_price_history)
-            assert 'Date' in result.columns
+            assert result.index.name == 'Date'
             assert 'Open' in result.columns
             assert 'High' in result.columns
             assert 'Low' in result.columns


### PR DESCRIPTION
## Summary
- The daily screening workflow's commit step only staged `data/fundamentals_cache/`, so `data/daily_scans/` (the actual scan reports) was never persisted to the repo — despite the README describing a committed full history. Now both are staged.
- Adds `.github/workflows/tests.yml` to run the pytest suite on push/PR — previously nothing ran it automatically.
- Fixes a stale assertion in `test_fetch_price_history_success` (checked `'Date' in result.columns`, but `fetch_price_history` documents and returns `Date` as the index).

## Test plan
- [x] `pytest tests/ --ignore=tests/test_email_full.py` passes locally (89/89)
- [x] `test_email_full.py` excluded from CI since it's a manual smoke-test script (live network/DB/email), not a unit test
- [ ] Confirm the daily workflow actually commits `data/daily_scans/` content after the next scheduled run