### PR TITLE
Make optional API key setup discoverable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,13 @@ SCREENING_MIN_SIGNAL=50
 # Robinhood Integration (optional - read-only position tracking)
 # Only username needed - password and SMS MFA are prompted interactively (never stored)
 # ROBINHOOD_USERNAME=your-email@example.com
+#
+# ROBINHOOD_PASSWORD is read from env ONLY by the automated GitHub Actions path
+# (automated_position_report.py). Set it as a GitHub Actions secret, never in a
+# local .env file - manual runs (manage_positions.py) always prompt interactively.
+
+# Financial Modeling Prep (FMP) Integration (optional - enhanced quarterly fundamentals)
+# Free tier: 250 requests/day. Get a free key at:
+# https://site.financialmodelingprep.com/developer/docs
+# Setup guide: docs/SETUP_FMP.md
+# FMP_API_KEY=your_fmp_api_key_here

--- a/README.md
+++ b/README.md
@@ -346,8 +346,11 @@ pip install robin-stocks
 # Copy environment template
 cp .env.example .env
 
-# Edit .env (only needed for manual position management)
-# Add: ROBINHOOD_USERNAME=your_email@example.com
+# Edit .env to enable optional integrations (FMP fundamentals, email/Slack
+# alerts, Robinhood position tracking) - none are required for a basic scan.
+
+# Check what's configured
+python scripts/check_setup.py
 ```
 
 ### Run Your First Scan

--- a/scripts/check_setup.py
+++ b/scripts/check_setup.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Check which optional integrations are configured.
+
+Usage:
+    python scripts/check_setup.py
+
+Reads the same environment variables the app reads (via .env, loaded with
+python-dotenv) and reports what's set, what's missing, and whether each
+missing item is required or optional.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+OPTIONAL = [
+    (
+        "DATABASE_URL",
+        "Falls back to sqlite:///./stock_screener.db if unset - fine for local use.",
+    ),
+    (
+        "FMP_API_KEY",
+        "Enhanced quarterly fundamentals (net margins, inventory). "
+        "Free tier, 250 req/day. See docs/SETUP_FMP.md.",
+    ),
+    (
+        "EMAIL_FROM",
+        "Email notifications for daily scan results. See docs/NOTIFICATIONS_SETUP.md.",
+    ),
+    (
+        "SLACK_WEBHOOK_URL",
+        "Slack notifications for daily scan results. See docs/NOTIFICATIONS_SETUP.md.",
+    ),
+    (
+        "ROBINHOOD_USERNAME",
+        "Read-only Robinhood position tracking. See docs/ROBINHOOD_SETUP.md. "
+        "Password is prompted interactively for manual runs - never put "
+        "ROBINHOOD_PASSWORD in a local .env file.",
+    ),
+]
+
+
+def check(name: str, note: str) -> None:
+    if os.getenv(name):
+        print(f"  ✅ {name} is set")
+    else:
+        print(f"  ⚠️  {name} not set")
+        print(f"     {note}")
+
+
+def main() -> int:
+    print("Stock Screener - Environment Setup Check")
+    print("=" * 60)
+    print("\nNothing here is required to run a scan - all integrations")
+    print("are opt-in. This just shows what's configured.\n")
+
+    print("Optional integrations:")
+    for name, note in OPTIONAL:
+        check(name, note)
+
+    print("\n" + "=" * 60)
+    print("Missing items above are fine to skip - see .env.example and")
+    print("the linked docs/ guide if you want to turn one on.")
+    print("=" * 60)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `FMP_API_KEY` is a real, working optional integration (`fmp_fetcher.py`, `enhanced_fundamentals.py`) with its own setup doc (`docs/SETUP_FMP.md`), but wasn't listed in `.env.example` or mentioned anywhere in the top-level setup flow. New devs had no way to discover it without reading source.
- Adds `FMP_API_KEY` to `.env.example` with a link to the setup doc.
- Adds a note that `ROBINHOOD_PASSWORD` is a GitHub Actions secret for the automated path only (`automated_position_report.py`) and should never go in a local `.env` - manual runs always prompt interactively.
- Adds `scripts/check_setup.py`: one command that prints which optional integrations are configured vs. not, with a doc link for each.
- Links the check from README's Configuration section.

## Test plan
- [x] `python scripts/check_setup.py` runs clean, correctly reports unset optional vars with doc links