### PR TITLE
Pin dependencies to exact versions, add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-yfinance>=0.2.66
-pandas>=2.2.0
-sqlalchemy>=2.0.20
-psycopg2-binary>=2.9.9
-python-dotenv>=1.0.0
-pytest>=7.4.0
-pytest-mock>=3.11.1
-requests>=2.31.0
-slack-sdk>=3.26.0
-pyyaml>=6.0
-numpy>=1.24.0
-robin-stocks>=3.0.0  # Read-only position tracking (optional)
+yfinance==1.7.0
+pandas==3.0.5
+sqlalchemy==2.0.52
+psycopg2-binary==2.9.12
+python-dotenv==1.2.3
+pytest==9.1.1
+pytest-mock==3.15.1
+requests==2.34.2
+slack-sdk==3.44.0
+pyyaml==6.0.3
+numpy==2.5.2
+robin-stocks==3.4.0  # Read-only position tracking (optional)


### PR DESCRIPTION
## Summary
`requirements.txt` had no upper bound on any dependency and no lockfile - a `pandas` or `numpy` major version bump could silently change behavior on the next CI run or scheduled scan, with no signal until something broke in production (we already hit one stale-test case from a pandas index/column drift this session).

- Pinned every dependency to its currently-resolving exact version
- Added `.github/dependabot.yml` (pip + github-actions ecosystems, weekly) so future upgrades show up as reviewable PRs instead of happening implicitly on the next `pip install`

## Test plan
- [x] Fresh venv, `pip install -r requirements.txt`, `pytest tests/ --ignore=tests/test_email_full.py` - 89/89 passing against the exact pinned versions