### PR TITLE
HOTFIX: Bump CI Python to 3.12 - requirements.txt broken on 3.11

### DIFF
--- a/.github/workflows/daily_screening_git_storage.yml
+++ b/.github/workflows/daily_screening_git_storage.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
## Urgent
The daily scan (`daily_screening_git_storage.yml`) is scheduled for 12:00 UTC and will fail without this - it uses the same broken `requirements.txt`/Python 3.11 combination that's already failing `tests.yml` on main.

## Summary
`numpy==2.5.2`, pinned in #6, requires Python >=3.12. Both workflows pin `python-version: '3.11'`, so `pip install -r requirements.txt` fails outright (confirmed in the failed run on main: "No matching distribution found for numpy==2.5.2"). This also broke the 4 Dependabot PRs Dependabot just opened (#7-#10), since they inherit the same requirements.txt.

Bumped both workflows to Python 3.12.

## Test plan
- [x] Fresh Python 3.12 venv, `pip install -r requirements.txt` from current main - installs clean
- [x] `pytest tests/ --ignore=tests/test_email_full.py` - 89/89 passing under 3.12